### PR TITLE
Changed user-agent modification to apply to more resource types

### DIFF
--- a/Extension/Resources/background.js
+++ b/Extension/Resources/background.js
@@ -82,7 +82,11 @@ function setUserAgent(userAgent) {
             priority: 1,
             condition: {
                 urlFilter: "*",
-                resourceTypes: ["main_frame"]
+            resourceTypes: [
+                                    "main_frame", "sub_frame", "stylesheet", "script", "image",
+                                    "object", "xmlhttprequest", "ping", "csp_report", "media",
+                                    "websocket", "other"
+                                ]
             },
             action: {
                 type: "modifyHeaders",
@@ -126,7 +130,11 @@ function setSiteSettings(siteSettings) {
                 priority: ruleId + 1,
                 condition: {
                     urlFilter: "||" + siteSetting.domain,
-                    resourceTypes: ["main_frame"]
+                resourceTypes: [
+                                    "main_frame", "sub_frame", "stylesheet", "script", "image",
+                                    "object", "xmlhttprequest", "ping", "csp_report", "media",
+                                    "websocket", "other"
+                                ]
                 },
                 action: {
                     type: "modifyHeaders",


### PR DESCRIPTION
Some websites (e.g. Microsoft Copilot/Bing Chat) check the user agent also in other requests, e.g. webpage scripts.
This led to Unagent not completely spoofing the user agent.

This PR changes the user agent in more resource types than just the HTML, thus restoring Copilot functionality on Safari.